### PR TITLE
Order relay webhook

### DIFF
--- a/foodhub/entities/tasks.py
+++ b/foodhub/entities/tasks.py
@@ -1,20 +1,46 @@
+from entities.serializers import OrderSerializer
 from entities.models import Merchant, Store, Order
 from celery.decorators import task
+from django.db.utils import OperationalError
 import structlog
+import requests
 
 log = structlog.get_logger()
 
 
-@task(name="create_order")
+@task(name="create_order", autoretry_for=(OperationalError,), retry_kwargs={
+    'max_retries': 5,
+    'countdown': 2})
 def create_order(data):
     """
     This function is used to create Order asynchronously.
     """
+    log.msg('Creating Order ', initial_data=data)
     merchant_instance = Merchant.objects.filter(pk=data['merchant']).first()
     store_instance = Store.objects.filter(pk=data['store']).first()
-    items = data.pop('items')
+    items = data['items']
     order_instance = Order.objects.create(
         merchant=merchant_instance, store=store_instance,
         total_cost=data['total_cost'])
     order_instance.items.set(items)
     log.msg('Order Created', orderID=order_instance.id)
+    serialized_order = OrderSerializer(order_instance)
+    log.msg('Serialized Order Data', data=serialized_order.data)
+    return serialized_order.data
+
+
+@task(name="relay_order", autoretry_for=(Exception,), retry_kwargs={
+    'max_retries': 5,
+    'countdown': 2}, retry_backoff=True)
+def relay_order(data):
+    """
+    Sends Order Details through POST Request to Merchant's URL webhook.
+
+    Arguments :
+    data : Serialized Order Data 
+    """
+    log.msg('Enter Order Relay', json=data)
+
+    response = requests.post(
+        'http://e3253a83fce4.ngrok.io/webhook/', params=data)
+    log.msg('Response Code ', status=response.status_code)

--- a/foodhub/entities/urls.py
+++ b/foodhub/entities/urls.py
@@ -10,4 +10,5 @@ router.register(r'orders', views.OrderViewSet)
 
 urlpatterns = [
     path('', include(router.urls)),
+    path('webhook/', views.webhook_endpoint)
 ]

--- a/foodhub/entities/views.py
+++ b/foodhub/entities/views.py
@@ -1,3 +1,7 @@
+import json
+from json.encoder import JSONEncoder
+
+from django.http.response import JsonResponse
 from rest_framework import viewsets, status
 from rest_framework.response import Response
 from rest_framework.decorators import action
@@ -6,9 +10,11 @@ from entities.serializers import (MerchantSerializer, ItemSerializer,
                                   StoreSerializer, OrderSerializer)
 from rest_framework.authentication import BasicAuthentication
 from rest_framework.permissions import IsAuthenticated
-from entities.tasks import create_order
+from entities.tasks import create_order, relay_order
+from django.http import HttpResponse
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_POST
 import structlog
-from silk.profiling.profiler import silk_profile
 
 # Create your views here.
 
@@ -103,10 +109,17 @@ class OrderViewSet(viewsets.ModelViewSet):
         log.msg('Create Order Request', req=request.data)
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
-        create_order.delay(serializer.data)
+        create_order.apply_async(args=[serializer.data], link=relay_order.s())
         headers = self.get_success_headers(serializer.validated_data)
         log.msg('Serializer Data', data=serializer.data,
                 validated_data=serializer.validated_data)
         response = {"message": "Order is being placed"}
         return Response(response, status=status.HTTP_201_CREATED,
                         headers=headers)
+
+
+@csrf_exempt
+@require_POST
+def webhook_endpoint(request):
+    log.msg('Inside Mock Merchant Webhook Endpoint')
+    return HttpResponse(status=200)


### PR DESCRIPTION
https://github.com/ray-abhishek/FoodHub/issues/14   --  Integrate Webhooks

Added an async task order_relay that is linked to the order_create task, so that every time an order is created, the order details are then sent in a POST request to a pre-configured merchant's webhook endpoint. 